### PR TITLE
docs: update `ddev get` to `ddev add-on get` in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,12 @@ Make sure you have [DDEV v1.22.1+ installed](https://ddev.readthedocs.io/en/late
 ### Install
 1. `cd` into your project directory
 2. Run `ddev config` and answer the questions as appropriate
-3. Run `ddev get reloxx13/ddev-swagger-ui` and answer the questions as appropriate
+3. Run `ddev add-on get reloxx13/ddev-swagger-ui` (or `ddev get reloxx13/ddev-swagger-ui` if your DDEV version is older than 1.23.5) and answer the questions as appropriate
 4. Run `ddev start` or `ddev restart`
 
 ### Upgrade
 
-To upgrade your version of ddev-swagger-ui, repeat the `ddev get reloxx13/ddev-swagger-ui` to get the latest release. To see the installed version, `ddev get --installed`.
+To upgrade your version of ddev-swagger-ui, repeat the `ddev add-on get reloxx13/ddev-swagger-ui` to get the latest release. To see the installed version, `ddev add-on list --installed`.
 
 ## Notes
 


### PR DESCRIPTION
In [DDEV 1.23.5](https://github.com/ddev/ddev/releases/tag/v1.23.5) the ddev get command was deprecated in favour of ddev add-on get.

This PR updates those references in the readme file. There may be some additional markdown improvements as well.

The changes were made manually, but the PR itself was automatically created - I'm doing over 100 of these. I apologise if its not 100% to the contributor standards required by this repo. Let me know if I need to change anything.